### PR TITLE
Fix wasm-pack compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ features = [
   "Window",
 ]
 
+[dev-dependencies]
+wasm-bindgen-test = "0.2"
+
 [profile.release]
 opt-level = "s"
 debug = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! console_log {
 
 // Global allocator setup removed - using default allocator
 
-#[wasm_bindgen(start)]
+#[cfg_attr(not(test), wasm_bindgen(start))]
 pub fn main() {
     console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
Conditionally apply `#[wasm_bindgen(start)]` and add `wasm-bindgen-test` to fix compilation errors when running `wasm-pack test`.

The `#[wasm_bindgen(start)]` attribute on the `main` function conflicts with the test runner's own entry point when `wasm-pack test` is executed. By using `#[cfg_attr(not(test), wasm_bindgen(start))]`, the attribute is only applied during normal builds, resolving the "entry symbol `main` declared multiple times" error. The `wasm-bindgen-test` dependency is also required for the test environment.